### PR TITLE
Fix % induced crash

### DIFF
--- a/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
+++ b/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
@@ -130,7 +130,8 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
 
             // log all mdc fields.
             for(String key : mdc.keySet()) {
-                messages.add(key + "=" + mdc.get(key));
+                messages.add(key + "=%s");
+                messages.add(mdc.get(key));
             }
             // the vararg list is null terminated
             messages.add(null);


### PR DESCRIPTION
Instead of `KEY=...value which might contain %...` we use `KEY=%s` and then pass the value as a literal following arg.